### PR TITLE
chore: bump plugin versions in helm chart

### DIFF
--- a/chart/validator/values.yaml
+++ b/chart/validator/values.yaml
@@ -108,7 +108,7 @@ plugins:
 - chart:
     name: validator-plugin-aws
     repository: "https://validator-labs.github.io/validator-plugin-aws"
-    version: v0.0.25
+    version: v0.0.26
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -143,7 +143,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/validator-labs/validator-plugin-aws
-          tag: v0.0.25
+          tag: v0.0.26
         resources:
           limits:
             cpu: 500m
@@ -177,7 +177,7 @@ plugins:
 - chart:
     name: validator-plugin-azure
     repository: "https://validator-labs.github.io/validator-plugin-azure"
-    version: v0.0.10
+    version: v0.0.11
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -212,7 +212,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/validator-labs/validator-plugin-azure
-          tag: v0.0.10
+          tag: v0.0.11
         resources:
           limits:
             cpu: 500m
@@ -252,7 +252,7 @@ plugins:
 - chart:
     name: validator-plugin-vsphere
     repository: "https://validator-labs.github.io/validator-plugin-vsphere"
-    version: v0.0.19
+    version: v0.0.20
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -287,7 +287,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/validator-labs/validator-plugin-vsphere
-          tag: v0.0.19
+          tag: v0.0.20
         resources:
           limits:
             cpu: 500m
@@ -313,7 +313,7 @@ plugins:
 - chart:
     name: validator-plugin-network
     repository: "https://validator-labs.github.io/validator-plugin-network"
-    version: v0.0.14
+    version: v0.0.15
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -350,7 +350,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/validator-labs/validator-plugin-network
-          tag: v0.0.14
+          tag: v0.0.15
         resources:
           limits:
             cpu: 500m
@@ -372,7 +372,7 @@ plugins:
 - chart:
     name: validator-plugin-oci
     repository: "https://validator-labs.github.io/validator-plugin-oci"
-    version: v0.0.9
+    version: v0.0.10
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -407,7 +407,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/validator-labs/validator-plugin-oci
-          tag: v0.0.9
+          tag: v0.0.10
         resources:
           limits:
             cpu: 500m
@@ -429,7 +429,7 @@ plugins:
 - chart:
     name: validator-plugin-kubescape
     repository: "https://validator-labs.github.io/validator-plugin-kubescape"
-    version: v0.0.2
+    version: v0.0.3
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -464,7 +464,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/validator-labs/validator-plugin-kubescape
-          tag: v0.0.2
+          tag: v0.0.3
         resources:
           limits:
             cpu: 500m

--- a/internal/controller/testdata/vc-network.yaml
+++ b/internal/controller/testdata/vc-network.yaml
@@ -14,7 +14,7 @@ spec:
       name: validator-plugin-network
       repository: https://validator-labs.github.io/validator-plugin-network
       authSecretName: validator-plugin-network-chart-secret
-      version: v0.0.4
+      version: v0.0.15
     values: |-
       controllerManager:
         kubeRbacProxy:
@@ -49,7 +49,7 @@ spec:
               - ALL
           image:
             repository: quay.io/validator-labs/validator-plugin-network
-            tag: v0.0.4
+            tag: v0.0.15
           resources:
             limits:
               cpu: 500m

--- a/internal/controller/validatorconfig_controller_test.go
+++ b/internal/controller/validatorconfig_controller_test.go
@@ -29,8 +29,8 @@ import (
 const (
 	networkPluginDeploymentName  = "validator-plugin-network-controller-manager"
 	networkPluginDeploymentImage = "quay.io/validator-labs/validator-plugin-network"
-	networkPluginVersionPre      = "v0.0.4"
-	networkPluginVersionPost     = "v0.0.5"
+	networkPluginVersionPre      = "v0.0.14"
+	networkPluginVersionPost     = "v0.0.15"
 )
 
 var (

--- a/internal/controller/validatorconfig_controller_test.go
+++ b/internal/controller/validatorconfig_controller_test.go
@@ -29,8 +29,8 @@ import (
 const (
 	networkPluginDeploymentName  = "validator-plugin-network-controller-manager"
 	networkPluginDeploymentImage = "quay.io/validator-labs/validator-plugin-network"
-	networkPluginVersionPre      = "v0.0.15"
-	networkPluginVersionPost     = "v0.0.16"
+	networkPluginVersionPre      = "v0.0.14"
+	networkPluginVersionPost     = "v0.0.15"
 )
 
 var (

--- a/internal/controller/validatorconfig_controller_test.go
+++ b/internal/controller/validatorconfig_controller_test.go
@@ -29,8 +29,8 @@ import (
 const (
 	networkPluginDeploymentName  = "validator-plugin-network-controller-manager"
 	networkPluginDeploymentImage = "quay.io/validator-labs/validator-plugin-network"
-	networkPluginVersionPre      = "v0.0.14"
-	networkPluginVersionPost     = "v0.0.15"
+	networkPluginVersionPre      = "v0.0.15"
+	networkPluginVersionPost     = "v0.0.16"
 )
 
 var (


### PR DESCRIPTION
Prior to these changes, installing the chart via the following command returns some errors:

```
helm install validator ./chart/validator -n validator --create-namespace
```
Errors seen in validator-controller-manager:
```
Error: failed to fetch https://spectrocloud-labs.github.io/validator-plugin-vsphere/validator-plugin-vsphere-0.0.19.tgz : 404 Not Found
```

After making the changes we're able to install charts succesfully using the above command and all plugins also download.

Note that for now installing the chart via the helm repo also fails with the same errors, so we'll need to get a new version of the helm chart pushed after this is merged:
```
helm install validator validator/validator -n validator --create-namespace
```

