### PR TITLE
fix: sink HTTP clients to read proxy config from environment

### DIFF
--- a/internal/sinks/alertmanager.go
+++ b/internal/sinks/alertmanager.go
@@ -84,7 +84,8 @@ func (s *AlertmanagerSink) Configure(c Client, config map[string][]byte) error {
 	if ok {
 		caCertPool, err = x509.SystemCertPool()
 		if err != nil {
-			return errors.Wrap(err, "invalid Alertmanager config: failed to get system cert pool")
+			s.log.Error(err, "failed to get system cert pool; using empty pool")
+			caCertPool = x509.NewCertPool()
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 	}

--- a/internal/sinks/sink.go
+++ b/internal/sinks/sink.go
@@ -40,9 +40,8 @@ type Client struct {
 
 // NewClient returns a new Client with the provided timeout.
 func NewClient(timeout time.Duration) *Client {
-	client := &http.Client{
-		Timeout: timeout,
-	}
+	client := http.DefaultClient // inherit http.ProxyFromEnvironment
+	client.Timeout = timeout
 	return &Client{
 		hclient: client,
 	}


### PR DESCRIPTION
## Issue
#159 

## Description
Use `http.DefaultClient`, rather than constructing our own HTTP client manually. This will load proxy config from `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables by default.

Additionally, make failure to load the system cert pool a non-fatal error.
