### PR TITLE
fix: ensure vsphere password is quoted

### DIFF
--- a/chart/validator/templates/plugin-secret-vsphere.yaml
+++ b/chart/validator/templates/plugin-secret-vsphere.yaml
@@ -4,8 +4,8 @@ kind: Secret
 metadata:
   name: {{ required ".Values.pluginSecrets.vSphere.secretName is required!" .Values.pluginSecrets.vSphere.secretName }}
 stringData:
-  username: {{ required ".Values.pluginSecrets.vSphere.username is required!" .Values.pluginSecrets.vSphere.username }}
-  password: {{ required ".Values.pluginSecrets.vSphere.password is required!" .Values.pluginSecrets.vSphere.password }}
-  vcenterServer: {{ required ".Values.pluginSecrets.vSphere.vcenterServer is required!" .Values.pluginSecrets.vSphere.vcenterServer }}
+  username: {{ required ".Values.pluginSecrets.vSphere.username is required!" .Values.pluginSecrets.vSphere.username | quote }}
+  password: {{ required ".Values.pluginSecrets.vSphere.password is required!" .Values.pluginSecrets.vSphere.password | quote }}
+  vcenterServer: {{ required ".Values.pluginSecrets.vSphere.vcenterServer is required!" .Values.pluginSecrets.vSphere.vcenterServer | quote }}
   insecureSkipVerify: {{ required ".Values.pluginSecrets.vSphere.insecureSkipVerify is required!" .Values.pluginSecrets.vSphere.insecureSkipVerify | quote }}
 {{- end }}


### PR DESCRIPTION
## Description
ensure the vsphere password is quoted to avoid any yaml to json conversion errors like the following:
```
Error: YAML parse error on validator/templates/plugin-secret-vsphere.yaml: error converting YAML to JSON: yaml: line 7: did not find expected comment or line break
```