### PR TITLE
feat: add GroupResource consts; set TypeMeta in Build

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -20,17 +20,37 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "validation.spectrocloud.labs", Version: "v1alpha1"}
+	// APIVersion is the API version used to reference v1alpha1 objects.
+	APIVersion = GroupVersion.String()
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// Group is the API group used to reference validator objects.
+	Group = "validation.spectrocloud.labs"
+
+	// GroupVersion is group version used to register these objects.
+	GroupVersion = schema.GroupVersion{Group: Group, Version: "v1alpha1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
+
+	// ValidatorConfigKind is the kind of the ValidatorConfig object.
+	ValidatorConfigKind = reflect.TypeOf(ValidatorConfig{}).Name()
+
+	// ValidatorConfigGroupResource is the name of the ValidatorConfig resource.
+	ValidatorConfigGroupResource = schema.GroupResource{Group: Group, Resource: "validatorconfigs"}
+
+	// ValidationResultKind is the kind of the ValidationResult object.
+	ValidationResultKind = reflect.TypeOf(ValidationResult{}).Name()
+
+	// ValidationResultGroupResource is the name of the ValidationResult resource.
+	ValidationResultGroupResource = schema.GroupResource{Group: Group, Resource: "validationresults"}
 )

--- a/pkg/validationresult/validation_result.go
+++ b/pkg/validationresult/validation_result.go
@@ -29,6 +29,7 @@ type Patcher interface {
 // ValidationRule is an interface for validation rules.
 type ValidationRule interface {
 	client.Object
+	Kind() string
 	PluginCode() string
 	ResultCount() int
 }
@@ -36,6 +37,10 @@ type ValidationRule interface {
 // Build creates a new ValidationResult for a specific ValidationRule.
 func Build(r ValidationRule) *v1alpha1.ValidationResult {
 	return &v1alpha1.ValidationResult{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.APIVersion,
+			Kind:       r.Kind(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      Name(r),
 			Namespace: r.GetNamespace(),

--- a/pkg/validationresult/validation_result.go
+++ b/pkg/validationresult/validation_result.go
@@ -29,7 +29,7 @@ type Patcher interface {
 // ValidationRule is an interface for validation rules.
 type ValidationRule interface {
 	client.Object
-	Kind() string
+	GetKind() string
 	PluginCode() string
 	ResultCount() int
 }
@@ -39,7 +39,7 @@ func Build(r ValidationRule) *v1alpha1.ValidationResult {
 	return &v1alpha1.ValidationResult{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.APIVersion,
-			Kind:       r.Kind(),
+			Kind:       r.GetKind(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      Name(r),


### PR DESCRIPTION
## Issue
Resolves #371

## Description
Once plugins implement `ValidationRule`, `Build` will populate `TypeMeta` properly.
