### PR TITLE
fix: ensure all added oci secrets are added to secrets template

### DIFF
--- a/chart/validator/templates/plugin-secret-oci-auth.yaml
+++ b/chart/validator/templates/plugin-secret-oci-auth.yaml
@@ -7,4 +7,5 @@ stringData:
   {{- range $key, $val := .env }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
+---
 {{- end }}


### PR DESCRIPTION
## Description
Previously when adding multiple oci secrets, only the last secret added to the values.yaml was being created. This change ensures that our oci-auth template does not overwrite previous secrets.
