### PR TITLE
refactor: new validation rule interface

### DIFF
--- a/hauler-manifest.yaml
+++ b/hauler-manifest.yaml
@@ -57,4 +57,4 @@ metadata:
 spec:
   files:
     - name: validatorctl
-      path: https://github.com/validator-labs/validatorctl/releases/download/v0.1.1/validator-linux-ARCH
+      path: https://github.com/validator-labs/validatorctl/releases/download/v0.1.2/validator-linux-ARCH

--- a/pkg/validationresult/validation_result.go
+++ b/pkg/validationresult/validation_result.go
@@ -26,7 +26,7 @@ type Patcher interface {
 	Patch(ctx context.Context, obj client.Object, opts ...patch.Option) error
 }
 
-// ValidationRule is an interface for validation rules.
+// ValidationRule is an interface for defining validation rules that are used to build a ValidationResult.
 type ValidationRule interface {
 	client.Object
 	GetKind() string

--- a/pkg/validationresult/validation_result.go
+++ b/pkg/validationresult/validation_result.go
@@ -26,16 +26,16 @@ type Patcher interface {
 	Patch(ctx context.Context, obj client.Object, opts ...patch.Option) error
 }
 
-// ValidationRule is an interface for defining validation rules that are used to build a ValidationResult.
-type ValidationRule interface {
+// Validator is an interface for building ValidationResults.
+type Validator interface {
 	client.Object
 	GetKind() string
 	PluginCode() string
 	ResultCount() int
 }
 
-// Build creates a new ValidationResult for a specific ValidationRule.
-func Build(r ValidationRule) *v1alpha1.ValidationResult {
+// Build creates a new ValidationResult for a specific Validator.
+func Build(r Validator) *v1alpha1.ValidationResult {
 	return &v1alpha1.ValidationResult{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.APIVersion,
@@ -61,8 +61,8 @@ func Build(r ValidationRule) *v1alpha1.ValidationResult {
 	}
 }
 
-// Name returns the name of a ValidationResult for a specific ValidationRule.
-func Name(r ValidationRule) string {
+// Name returns the name of a ValidationResult for a specific Validator.
+func Name(r Validator) string {
 	name := fmt.Sprintf("validator-plugin-%s-%s", r.PluginCode(), r.GetName())
 	return util.Sanitize(name)
 }

--- a/pkg/validationrule/validation_rule.go
+++ b/pkg/validationrule/validation_rule.go
@@ -1,0 +1,37 @@
+// Package validationrule describes validation rules in the Validator ecosystem.
+package validationrule
+
+// Interface defines validation rule behavior.
+type Interface interface {
+	// Name returns the name of the rule.
+	Name() string
+	// SetName sets the name of the rule if it is a rule that supports manually specified names.
+	SetName(string)
+	// AllowsManualName returns whether the validation rule allows manually specifying its name.
+	// Code processing rules should check this first before trying to set a manual name.
+	AllowsManualName() bool
+}
+
+// ManuallyNamed can be embedded into a rule struct to indicate that the rule allows its name to be
+// manually specified.
+type ManuallyNamed struct{}
+
+// AllowsManualName returns true, indicating that the rule supports manually specifying its name.
+func (ManuallyNamed) AllowsManualName() bool {
+	return true
+}
+
+// AutomaticallyNamed can be embedded into a rule struct to indicate that the rule does not allow its
+// name to be manually specified.
+type AutomaticallyNamed struct{}
+
+// AllowsManualName returns false, indicating that the rule does not support manually specifying its
+// name.
+func (AutomaticallyNamed) AllowsManualName() bool {
+	return false
+}
+
+// SetName is a no-op because the rule does not support manually specifying its name.
+func (AutomaticallyNamed) SetName(string) {
+	// no-op
+}

--- a/pkg/validationrule/validation_rule.go
+++ b/pkg/validationrule/validation_rule.go
@@ -1,33 +1,34 @@
-// Package validationrule describes validation rules in the Validator ecosystem.
+// Package validationrule describes validation rules.
 package validationrule
 
 // Interface defines validation rule behavior.
 type Interface interface {
 	// Name returns the name of the rule.
 	Name() string
-	// SetName sets the name of the rule if it is a rule that supports manually specified names.
+	// SetName sets the name of the rule if it is a rule that requires manually specifying its name.
+	// This should be a no-op for rules that automatically generate their name.
 	SetName(string)
-	// AllowsManualName returns whether the validation rule allows manually specifying its name.
-	// Code processing rules should check this first before trying to set a manual name.
-	AllowsManualName() bool
+	// RequiresName returns whether the validation rule requires its name to be manually specified.
+	// This should return false for rules that automatically generate their name.
+	RequiresName() bool
 }
 
-// ManuallyNamed can be embedded into a rule struct to indicate that the rule allows its name to be
-// manually specified.
+// ManuallyNamed can be embedded into a rule struct to indicate that the rule requires its name to
+// be manually specified.
 type ManuallyNamed struct{}
 
-// AllowsManualName returns true, indicating that the rule supports manually specifying its name.
-func (ManuallyNamed) AllowsManualName() bool {
+// RequiresName returns true.
+func (ManuallyNamed) RequiresName() bool {
 	return true
 }
 
-// AutomaticallyNamed can be embedded into a rule struct to indicate that the rule does not allow its
-// name to be manually specified.
+// AutomaticallyNamed can be embedded into a rule struct to indicate that the rule does not require
+// its name to be manually specified because it is automatically generated from other data in the
+// rule.
 type AutomaticallyNamed struct{}
 
-// AllowsManualName returns false, indicating that the rule does not support manually specifying its
-// name.
-func (AutomaticallyNamed) AllowsManualName() bool {
+// RequiresName returns false.
+func (AutomaticallyNamed) RequiresName() bool {
 	return false
 }
 


### PR DESCRIPTION
## Description
New interface to help with working with rule names in a consistent way across the ecosystem.

Plugins would be required to implement it for easy integration with programs like `validatorctl`. They can do that by embedding `validationrule.ManuallyNamed` or `validationrule.AutomaticallyNamed` into their rule struct and implementing the required methods. If they embed `validationrule.AutomaticallyNamed`, they don't need to implement `SetName`. Example:

```go
type MyRule struct {
	validationrule.ManuallyNamed `json:",inline"`

	...
}
```

They should also assert that their rule implements the interface. Example:

```go
var _ validationrule.Interface = (*MyRule)(nil)
```

For rules that are manually named, it is expected that only pointers to rules can implement the interface because of the pointer receiver of implementations of `SetName`. Example:

```go
func (r *MyRule) SetName(name string) { ... }
```