### PR TITLE
chore: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "config:base",
     "helpers:pinGitHubActionDigests",
     ":gitSignOff",
-    ":semanticCommitTypeAll(deps)"
+    ":semanticCommitTypeAll(deps)",
+    "group:allNonMajor"
   ],
   "addLabels": ["dependencies"],
   "postUpdateOptions": [


### PR DESCRIPTION
Adds `group:allNonMajor` for fewer dep update PRs going forward.